### PR TITLE
feat(baggage): extra css

### DIFF
--- a/presets/webpack-preset-unity/index.js
+++ b/presets/webpack-preset-unity/index.js
@@ -67,7 +67,7 @@ const config = {
             },
             {
                 test: /\/src\/.+\.jsx?$/,
-                loader: 'baggage?style.css',
+                loader: 'baggage?style.css&[file].css',
                 include: srcPath
             }
         ],


### PR DESCRIPTION
auto-load .css files with the same name as .js files

**Reasoning:**
You can have a directory with components
```
Title.jsx
Title.css
Description.jsx
Description.css
```
that way you won't have to share  single `style.css` between all of your components in the directory